### PR TITLE
added shipping as default variable

### DIFF
--- a/02-default-templates/source-files/ecommerce/index.html
+++ b/02-default-templates/source-files/ecommerce/index.html
@@ -17,6 +17,7 @@
     <meta name="stripe-company" content="Acme Co.">
     <meta name="stripe-title" content="Parrot line">
     <meta name="stripe-price" content="1999">
+    <meta name="stripe-shipping" content="true">
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.js"></script>
   <!--[if lt IE 9]>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/respond.js/1.4.2/respond.js"></script>


### PR DESCRIPTION
I am having issues with the shipping info disappearing whenever I update any files in my dropbox. I think shipping should be default and if someone doesn't want it they can change it to 'false' in the settings.txt file.